### PR TITLE
Remove unlock done in lockFlex function

### DIFF
--- a/cros_gralloc/gralloc1/cros_gralloc1_module.cc
+++ b/cros_gralloc/gralloc1/cros_gralloc1_module.cc
@@ -397,8 +397,6 @@ int32_t CrosGralloc1::lockFlex(
        /* convert the data in flex format*/
        update_flex_layout( &ycbcrData, outData);
 
-       ret = unlock(bufferHandle, &outReleaseFence);
-
        return ret;
 }
 


### PR DESCRIPTION
As per lockFlex function doc, lockFlex function should
lock the given buffer for the specified usage and also
should return an android_flex_layout struct describing
how to access the data planes. So, lockFlex function
should not unlock the buffer instead the clients
needs to call the unlock function to unlock the buffer.

Jira: None
Test: Device boots and camera works

Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>