### PR TITLE
AndroidIA: Store the requested width and height.

### DIFF
--- a/cros_gralloc/cros_gralloc_driver.cc
+++ b/cros_gralloc/cros_gralloc_driver.cc
@@ -146,6 +146,8 @@ int32_t cros_gralloc_driver::allocate(const struct cros_gralloc_buffer_descripto
 	hnd->usage = descriptor->producer_usage;
 	hnd->producer_usage = descriptor->producer_usage;
 	hnd->consumer_usage = descriptor->consumer_usage;
+	hnd->requested_width = descriptor->width;
+	hnd->requested_height = descriptor->height;
 
 	id = drv_bo_get_plane_handle(bo, 0).u32;
 	auto buffer = new cros_gralloc_buffer(id, bo, hnd);

--- a/cros_gralloc/cros_gralloc_handle.h
+++ b/cros_gralloc/cros_gralloc_handle.h
@@ -34,6 +34,8 @@ struct cros_gralloc_handle {
 	int32_t usage; /* Android usage. */
 	uint32_t consumer_usage;
 	uint32_t producer_usage;
+	uint32_t requested_width;
+	uint32_t requested_height;
 };
 
 typedef const struct cros_gralloc_handle *cros_gralloc_handle_t;


### PR DESCRIPTION
Keep a copy of the requested width and height in cros gralloc handle

Signed-off-by: Harish Krupo <harish.krupo.kps@intel.com>