### PR TITLE
AndroidIA: add more formats in i915_private

### DIFF
--- a/cros_gralloc/i915_private_android.cc
+++ b/cros_gralloc/i915_private_android.cc
@@ -32,6 +32,8 @@ uint32_t i915_private_convert_format(int format)
 		return DRM_FORMAT_NV16;
 	case HAL_PIXEL_FORMAT_YCbCr_422_888:
 		return DRM_FORMAT_YUV422;
+	case HAL_PIXEL_FORMAT_P010_INTEL:
+		return DRM_FORMAT_P010_INTEL;
 	}
 
 	return DRM_FORMAT_NONE;
@@ -65,6 +67,8 @@ int32_t i915_private_invert_format(int format)
 		return HAL_PIXEL_FORMAT_YCbCr_422_I;
 	case DRM_FORMAT_R16:
 		return HAL_PIXEL_FORMAT_Y16;
+	case DRM_FORMAT_P010_INTEL:
+		return HAL_PIXEL_FORMAT_P010_INTEL;
 	case DRM_FORMAT_YUV444:
 		return HAL_PIXEL_FORMAT_YCbCr_444_888;
 	case DRM_FORMAT_NV21:
@@ -90,6 +94,7 @@ bool i915_private_supported_yuv_format(uint32_t droid_format)
 	case HAL_PIXEL_FORMAT_YCbCr_444_888:
 	case HAL_PIXEL_FORMAT_YCrCb_420_SP:
 	case HAL_PIXEL_FORMAT_Y16:
+	case HAL_PIXEL_FORMAT_P010_INTEL:
 		return true;
 	default:
 		return false;

--- a/i915_private.c
+++ b/i915_private.c
@@ -22,9 +22,9 @@
 
 static const uint32_t private_linear_source_formats[] = { DRM_FORMAT_R16,    DRM_FORMAT_NV16,
 							  DRM_FORMAT_YUV420, DRM_FORMAT_YUV422,
-							  DRM_FORMAT_YUV444, DRM_FORMAT_NV21 };
+							  DRM_FORMAT_YUV444, DRM_FORMAT_NV21, DRM_FORMAT_P010_INTEL};
 
-static const uint32_t private_source_formats[] = { DRM_FORMAT_NV12_Y_TILED_INTEL };
+static const uint32_t private_source_formats[] = { DRM_FORMAT_P010_INTEL, DRM_FORMAT_NV12_Y_TILED_INTEL };
 
 #if !defined(DRM_CAP_CURSOR_WIDTH)
 #define DRM_CAP_CURSOR_WIDTH 0x8
@@ -140,6 +140,8 @@ uint32_t i915_private_bpp_from_format(uint32_t format, size_t plane)
 	switch (format) {
 	case DRM_FORMAT_NV12_Y_TILED_INTEL:
 		return (plane == 0) ? 8 : 4;
+	case DRM_FORMAT_P010_INTEL:
+		return (plane == 0) ? 16 : 8;
 	case DRM_FORMAT_YUV420:
 	case DRM_FORMAT_YUV422:
 	case DRM_FORMAT_YUV444:
@@ -159,6 +161,7 @@ void i915_private_vertical_subsampling_from_format(uint32_t *vertical_subsamplin
 	switch (format) {
 	case DRM_FORMAT_NV12_Y_TILED_INTEL:
 	case DRM_FORMAT_YUV420:
+	case DRM_FORMAT_P010_INTEL:
 		*vertical_subsampling = (plane == 0) ? 1 : 2;
 		break;
 	default:
@@ -173,6 +176,7 @@ size_t i915_private_num_planes_from_format(uint32_t format)
 		return 1;
 	case DRM_FORMAT_NV12_Y_TILED_INTEL:
 	case DRM_FORMAT_NV16:
+	case DRM_FORMAT_P010_INTEL:
 		return 2;
 	case DRM_FORMAT_YUV420:
 	case DRM_FORMAT_YUV422:

--- a/i915_private_types.h
+++ b/i915_private_types.h
@@ -7,5 +7,7 @@
 #ifdef DRV_I915
 
 #define DRM_FORMAT_NV12_Y_TILED_INTEL fourcc_code('9', '9', '9', '6')
+#define DRM_FORMAT_P010_INTEL         fourcc_code('9', '9', '9', '5')
+
 
 #endif


### PR DESCRIPTION
Those formats with special layout are potencially
need by camera usage and encode can take them as
input.
JIRA: None
Test: None

Signed-off-by: Johnson Lin <johnson.lin@intel.com>