### PR TITLE
Add BO_USAGE_RENDERING to YUYV/VYUY formats

### DIFF
--- a/i915.c
+++ b/i915.c
@@ -28,7 +28,7 @@ static const uint32_t render_target_formats[] = { DRM_FORMAT_ARGB1555, DRM_FORMA
 
 static const uint32_t tileable_texture_source_formats[] = { DRM_FORMAT_GR88, DRM_FORMAT_NV12,
 							    DRM_FORMAT_R8, DRM_FORMAT_UYVY,
-							    DRM_FORMAT_YUYV };
+							    DRM_FORMAT_YUYV, DRM_FORMAT_YVYU, DRM_FORMAT_VYUY };
 
 static const uint32_t texture_source_formats[] = { DRM_FORMAT_YVU420, DRM_FORMAT_YVU420_ANDROID };
 

--- a/i915_private.c
+++ b/i915_private.c
@@ -82,7 +82,13 @@ int i915_private_add_combinations(struct driver *drv)
 	drv_modify_combination(drv, DRM_FORMAT_NV12, &metadata,
 			       BO_USE_RENDERING | BO_USE_TEXTURE | BO_USE_CAMERA_MASK);
 	drv_modify_combination(drv, DRM_FORMAT_YUYV, &metadata,
-			       BO_USE_TEXTURE | BO_USE_CAMERA_MASK);
+			       BO_USE_TEXTURE | BO_USE_CAMERA_MASK | BO_USE_RENDERING);
+	drv_modify_combination(drv, DRM_FORMAT_VYUY, &metadata,
+			       BO_USE_TEXTURE | BO_USE_CAMERA_MASK | BO_USE_RENDERING);
+	drv_modify_combination(drv, DRM_FORMAT_UYVY, &metadata,
+			       BO_USE_TEXTURE | BO_USE_CAMERA_MASK | BO_USE_RENDERING);
+	drv_modify_combination(drv, DRM_FORMAT_YVYU, &metadata,
+			       BO_USE_TEXTURE | BO_USE_CAMERA_MASK | BO_USE_RENDERING);
 	drv_modify_combination(drv, DRM_FORMAT_YVU420_ANDROID, &metadata,
 			       BO_USE_TEXTURE | BO_USE_CAMERA_MASK);
 


### PR DESCRIPTION
This is needed for overlay input with YUYV/VYUY formats.

Signed-off-by: Xiaosong Wei <xiaosong.wei@intel.com>