### PR TITLE
Fix capture not working with YCbCr_420_888 in Android

### DIFF
--- a/cros_gralloc/gralloc1/cros_gralloc1_module.cc
+++ b/cros_gralloc/gralloc1/cros_gralloc1_module.cc
@@ -354,19 +354,29 @@ android_flex_plane_t ycbcrplanes[3];
 
 int32_t update_flex_layout(struct android_ycbcr *ycbcr, struct android_flex_layout *outFlexLayout)
 {
-	/*Need to add generic support*/
-	ycbcrplanes[0].component = FLEX_COMPONENT_Y;
-	ycbcrplanes[0].top_left = (uint8_t *)ycbcr->y;
-	ycbcrplanes[0].h_increment = ycbcr->ystride;
-	ycbcrplanes[1].component = FLEX_COMPONENT_Cb;
-	ycbcrplanes[1].top_left = (uint8_t *)ycbcr->cb;
-	ycbcrplanes[1].h_increment = ycbcr->cstride;
-	ycbcrplanes[2].component = FLEX_COMPONENT_Cr;
-	ycbcrplanes[2].top_left = (uint8_t *)ycbcr->cr;
-	ycbcrplanes[2].h_increment = ycbcr->chroma_step;
 	outFlexLayout->format = FLEX_FORMAT_YCbCr;
-	outFlexLayout->planes = ycbcrplanes;
 	outFlexLayout->num_planes = 3;
+	for (uint32_t i = 0; i < outFlexLayout->num_planes; i++) {
+		ycbcrplanes[i].bits_per_component = 8;
+		ycbcrplanes[i].bits_used = 8;
+	}
+
+	ycbcrplanes[0].top_left = static_cast<uint8_t *>(ycbcr->y);
+	ycbcrplanes[0].component = FLEX_COMPONENT_Y;
+	ycbcrplanes[0].h_increment = 1;
+	ycbcrplanes[0].v_increment = static_cast<int32_t>(ycbcr->ystride);
+
+	ycbcrplanes[1].top_left = static_cast<uint8_t *>(ycbcr->cb);
+	ycbcrplanes[1].component = FLEX_COMPONENT_Cb;
+	ycbcrplanes[1].h_increment = static_cast<int32_t>(ycbcr->chroma_step);
+	ycbcrplanes[1].v_increment = static_cast<int32_t>(ycbcr->cstride);
+
+	ycbcrplanes[2].top_left = static_cast<uint8_t *>(ycbcr->cr);
+	ycbcrplanes[2].component = FLEX_COMPONENT_Cr;
+	ycbcrplanes[2].h_increment = static_cast<int32_t>(ycbcr->chroma_step);
+	ycbcrplanes[2].v_increment = static_cast<int32_t>(ycbcr->cstride);
+
+	outFlexLayout->planes = ycbcrplanes;
 	return 0;
 }
 


### PR DESCRIPTION
Mapping of YCbCr paramters to FlexLayOut parameters not done
correctly causing camera app to crash.

As per doc, ystride is the Y slice index delta between
vertically adjacent pixes and cstride is the cb and cr slice
index delta between vertically adjacent pixels. So, v_increment
has to be set to strides.

Fix the issues by setting v_increment, h_increment,
bits_per_component and bits_used correctly.

Tests done:
- Image capture
- Video recording and playback

Change-Id: Idbfd6eb14f5a22b31b33eeb501369e991c297bcb
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
Signed-off-by: Yin Zhiye <zhiyex.yin@intel.com>