### PR TITLE
Add P010 support

### DIFF
--- a/cros_gralloc/gralloc1/cros_gralloc1_module.cc
+++ b/cros_gralloc/gralloc1/cros_gralloc1_module.cc
@@ -455,6 +455,14 @@ int32_t CrosGralloc1::lockYCbCr(buffer_handle_t bufferHandle,
 		ycbcr->cstride = hnd->strides[1];
 		ycbcr->chroma_step = 1;
 		break;
+	case DRM_FORMAT_P010:
+		ycbcr->y = addr[0];
+		ycbcr->cb = addr[1];
+		ycbcr->cr = addr[1] + 2;
+		ycbcr->ystride = hnd->strides[0];
+		ycbcr->cstride = hnd->strides[1];
+		ycbcr->chroma_step = 4;
+		break;
 	default:
 		return CROS_GRALLOC_ERROR_UNSUPPORTED;
 	}

--- a/cros_gralloc/i915_private_android.cc
+++ b/cros_gralloc/i915_private_android.cc
@@ -32,6 +32,8 @@ uint32_t i915_private_convert_format(int format)
 		return DRM_FORMAT_NV16;
 	case HAL_PIXEL_FORMAT_YCbCr_422_888:
 		return DRM_FORMAT_YUV422;
+	case HAL_PIXEL_FORMAT_P010_INTEL:
+		return DRM_FORMAT_P010;
 	}
 
 	return DRM_FORMAT_NONE;
@@ -65,6 +67,8 @@ int32_t i915_private_invert_format(int format)
 		return HAL_PIXEL_FORMAT_YCbCr_422_I;
 	case DRM_FORMAT_R16:
 		return HAL_PIXEL_FORMAT_Y16;
+	case DRM_FORMAT_P010:
+		return HAL_PIXEL_FORMAT_P010_INTEL;
 	case DRM_FORMAT_YUV444:
 		return HAL_PIXEL_FORMAT_YCbCr_444_888;
 	case DRM_FORMAT_NV21:
@@ -90,6 +94,7 @@ bool i915_private_supported_yuv_format(uint32_t droid_format)
 	case HAL_PIXEL_FORMAT_YCbCr_444_888:
 	case HAL_PIXEL_FORMAT_YCrCb_420_SP:
 	case HAL_PIXEL_FORMAT_Y16:
+	case HAL_PIXEL_FORMAT_P010_INTEL:
 		return true;
 	default:
 		return false;

--- a/i915_private.c
+++ b/i915_private.c
@@ -22,9 +22,10 @@
 
 static const uint32_t private_linear_source_formats[] = { DRM_FORMAT_R16,    DRM_FORMAT_NV16,
 							  DRM_FORMAT_YUV420, DRM_FORMAT_YUV422,
-							  DRM_FORMAT_YUV444, DRM_FORMAT_NV21 };
+							  DRM_FORMAT_YUV444, DRM_FORMAT_NV21,
+							  DRM_FORMAT_P010 };
 
-static const uint32_t private_source_formats[] = { DRM_FORMAT_NV12_Y_TILED_INTEL };
+static const uint32_t private_source_formats[] = { DRM_FORMAT_P010, DRM_FORMAT_NV12_Y_TILED_INTEL };
 
 #if !defined(DRM_CAP_CURSOR_WIDTH)
 #define DRM_CAP_CURSOR_WIDTH 0x8
@@ -140,6 +141,8 @@ uint32_t i915_private_bpp_from_format(uint32_t format, size_t plane)
 	switch (format) {
 	case DRM_FORMAT_NV12_Y_TILED_INTEL:
 		return (plane == 0) ? 8 : 4;
+	case DRM_FORMAT_P010:
+		return (plane == 0) ? 16 : 8;
 	case DRM_FORMAT_YUV420:
 	case DRM_FORMAT_YUV422:
 	case DRM_FORMAT_YUV444:
@@ -159,6 +162,7 @@ void i915_private_vertical_subsampling_from_format(uint32_t *vertical_subsamplin
 	switch (format) {
 	case DRM_FORMAT_NV12_Y_TILED_INTEL:
 	case DRM_FORMAT_YUV420:
+	case DRM_FORMAT_P010:
 		*vertical_subsampling = (plane == 0) ? 1 : 2;
 		break;
 	default:
@@ -173,6 +177,7 @@ size_t i915_private_num_planes_from_format(uint32_t format)
 		return 1;
 	case DRM_FORMAT_NV12_Y_TILED_INTEL:
 	case DRM_FORMAT_NV16:
+	case DRM_FORMAT_P010:
 		return 2;
 	case DRM_FORMAT_YUV420:
 	case DRM_FORMAT_YUV422:


### PR DESCRIPTION
P010 is 10bit 2 plane2 YUV420 format
which can be used by HEVC 10 bit

Change-Id: I0fc3c56e8a09fca0640c34699c3c149772c978a0
Jira: https://jira01.devtools.intel.com/browse/OAM-50293
Signed-off-by: Lin Johnson <johnson.lin@intel.com>