### PR TITLE
Fix errors after rebase

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -52,6 +52,8 @@ LOCAL_CFLAGS += -DDRV_I915
 LOCAL_SHARED_LIBRARIES += libdrm_intel
 endif
 
+LOCAL_SHARED_LIBRARIES += libnativewindow
+
 LOCAL_MODULE := gralloc.$(TARGET_BOARD_PLATFORM)
 LOCAL_MODULE_TAGS := optional
 # The preferred path for vendor HALs is /vendor/lib/hw

--- a/cros_gralloc/cros_gralloc_driver.cc
+++ b/cros_gralloc/cros_gralloc_driver.cc
@@ -126,6 +126,7 @@ int32_t cros_gralloc_driver::allocate(const struct cros_gralloc_buffer_descripto
 		hnd->fds[plane] = drv_bo_get_plane_fd(bo, plane);
 		hnd->strides[plane] = drv_bo_get_plane_stride(bo, plane);
 		hnd->offsets[plane] = drv_bo_get_plane_offset(bo, plane);
+		hnd->sizes[plane] = drv_bo_get_plane_size(bo, plane);
 
 		mod = drv_bo_get_plane_format_modifier(bo, plane);
 		hnd->format_modifiers[2 * plane] = static_cast<uint32_t>(mod >> 32);

--- a/cros_gralloc/cros_gralloc_handle.h
+++ b/cros_gralloc/cros_gralloc_handle.h
@@ -22,6 +22,7 @@ struct cros_gralloc_handle {
 	int32_t fds[DRV_MAX_PLANES];
 	uint32_t strides[DRV_MAX_PLANES];
 	uint32_t offsets[DRV_MAX_PLANES];
+	uint32_t sizes[DRV_MAX_PLANES];
 	uint32_t format_modifiers[2 * DRV_MAX_PLANES];
 	uint32_t width;
 	uint32_t height;

--- a/cros_gralloc/gralloc1/cros_gralloc1_module.cc
+++ b/cros_gralloc/gralloc1/cros_gralloc1_module.cc
@@ -476,6 +476,14 @@ int32_t CrosGralloc1::lockYCbCr(buffer_handle_t bufferHandle,
 		ycbcr->cstride = hnd->strides[1];
 		ycbcr->chroma_step = 1;
 		break;
+	case DRM_FORMAT_P010:
+		ycbcr->y = addr[0];
+		ycbcr->cb = addr[1];
+		ycbcr->cr = addr[1] + 2;
+		ycbcr->ystride = hnd->strides[0];
+		ycbcr->cstride = hnd->strides[1];
+		ycbcr->chroma_step = 4;
+		break;
 	default:
 		return CROS_GRALLOC_ERROR_UNSUPPORTED;
 	}


### PR DESCRIPTION
1) Bring sizes field back to
   gralloc_handle for binary consistant
2) Add missing P010 changes
3) Change Android.mk to add libnativewindow to
   make it compile in 1A

Jira: None
Test: Video playback h2.64 and 10 bit HEVC
Signed-off-by: Lin Johnson <johnson.lin@intel.com>