### PR TITLE
Suppress compile warnings unused-parameter and unused-value

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -40,11 +40,11 @@ LOCAL_SRC_FILES := \
 include $(MINIGBM_GRALLOC_MK)
 
 LOCAL_CPPFLAGS += -std=c++14 -D_GNU_SOURCE=1 -D_FILE_OFFSET_BITS=64 \
-                  -Wno-unused-parameter -Wno-switch -Wno-format \
-                  -Wno-unused-variable
+                  -Wno-switch -Wno-format -Wno-unused-variable
 LOCAL_CFLAGS += -Wall -Wsign-compare -Wpointer-arith \
 		-Wcast-qual -Wcast-align \
-		-D_GNU_SOURCE=1 -D_FILE_OFFSET_BITS=64
+		-D_GNU_SOURCE=1 -D_FILE_OFFSET_BITS=64 \
+		-Wno-unused-value -Wno-unused-parameter
 
 ifneq ($(filter $(intel_drivers), $(BOARD_GPU_DRIVERS)),)
 LOCAL_CPPFLAGS += -DDRV_I915


### PR DESCRIPTION
Jira: None.
Test: Build passes on Android and no warnings reported.