### PR TITLE
Extend the search scope of c header files

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -55,7 +55,7 @@ endif
 ifeq ($(shell test $(PLATFORM_SDK_VERSION) -ge 27; echo $$?), 0)
 LOCAL_SHARED_LIBRARIES += libnativewindow
 LOCAL_STATIC_LIBRARIES += libarect
-LOCAL_HEADER_LIBRARIES += libnativebase_headers
+LOCAL_HEADER_LIBRARIES += libnativebase_headers libsystem_headers libhardware_headers libutils_headers
 LOCAL_CFLAGS += -DUSE_VNDK
 endif
 


### PR DESCRIPTION
When VNDK enabled, system strict the header file search
scope, this patch extend the c includes search scope

Change-Id: I9f71870287f64e3a3d90a03eca9316041440663a
Jira: None.
Test: Build should pass
Signed-off-by: Chen Yu Y <yu.y.chen@intel.com>