### PR TITLE
Remove the reject checking for HAL_PIXEL_FORMAT_YCbCr_420_888

### DIFF
--- a/cros_gralloc/gralloc1/cros_gralloc1_module.cc
+++ b/cros_gralloc/gralloc1/cros_gralloc1_module.cc
@@ -366,11 +366,6 @@ int32_t CrosGralloc1::lock(buffer_handle_t bufferHandle, gralloc1_producer_usage
 		return CROS_GRALLOC_ERROR_BAD_HANDLE;
 	}
 
-	if ((hnd->droid_format == HAL_PIXEL_FORMAT_YCbCr_420_888)) {
-		cros_gralloc_error("HAL_PIXEL_FORMAT_YCbCr_*_888 format not compatible.");
-		return CROS_GRALLOC_ERROR_BAD_HANDLE;
-	}
-
 	map_flags = cros_gralloc1_convert_map_usage(producerUsage, consumerUsage);
 
 	if (driver->lock(bufferHandle, acquireFence, map_flags, addr))


### PR DESCRIPTION
This format is used in VTS tests
VTS use it as default color format

Jira: https://jira01.devtools.intel.com/browse/OAM-49221
Test: None
Signed-off-by: Lin Johnson <johnson.lin@intel.com>