### PR TITLE
fix buffer overflow when copy NV12 to YVU420

### DIFF
--- a/i915.c
+++ b/i915.c
@@ -31,7 +31,7 @@ static const uint32_t tileable_texture_source_formats[] = { DRM_FORMAT_GR88, DRM
 							    DRM_FORMAT_R8, DRM_FORMAT_UYVY,
 							    DRM_FORMAT_YUYV, DRM_FORMAT_YVYU, DRM_FORMAT_VYUY };
 
-static const uint32_t texture_source_formats[] = { DRM_FORMAT_YVU420, DRM_FORMAT_YVU420_ANDROID };
+static const uint32_t texture_source_formats[] = { DRM_FORMAT_NV12, DRM_FORMAT_YVU420, DRM_FORMAT_YVU420_ANDROID };
 
 struct i915_device {
 	uint32_t gen;
@@ -572,7 +572,7 @@ static uint32_t i915_resolve_format(uint32_t format, uint64_t use_flags)
 		/* KBL camera subsystem requires NV12. */
 		if (use_flags & (BO_USE_CAMERA_READ | BO_USE_CAMERA_WRITE))
 			return DRM_FORMAT_NV12;
-		return DRM_FORMAT_YVU420;
+		return DRM_FORMAT_NV12;
 	default:
 		return format;
 	}

--- a/mediatek.c
+++ b/mediatek.c
@@ -27,7 +27,7 @@ static const uint32_t render_target_formats[] = { DRM_FORMAT_ABGR8888, DRM_FORMA
 						  DRM_FORMAT_RGB565, DRM_FORMAT_XBGR8888,
 						  DRM_FORMAT_XRGB8888 };
 
-static const uint32_t texture_source_formats[] = { DRM_FORMAT_R8, DRM_FORMAT_YVU420,
+static const uint32_t texture_source_formats[] = { DRM_FORMAT_R8, DRM_FORMAT_NV12, DRM_FORMAT_YVU420,
 						   DRM_FORMAT_YVU420_ANDROID };
 
 static int mediatek_init(struct driver *drv)

--- a/virtio_gpu.c
+++ b/virtio_gpu.c
@@ -15,7 +15,7 @@ static const uint32_t render_target_formats[] = { DRM_FORMAT_ABGR8888, DRM_FORMA
 						  DRM_FORMAT_RGB565, DRM_FORMAT_XBGR8888,
 						  DRM_FORMAT_XRGB8888 };
 
-static const uint32_t texture_source_formats[] = { DRM_FORMAT_R8, DRM_FORMAT_YVU420,
+static const uint32_t texture_source_formats[] = { DRM_FORMAT_R8, DRM_FORMAT_NV12, DRM_FORMAT_YVU420,
 						   DRM_FORMAT_YVU420_ANDROID };
 
 static int virtio_gpu_init(struct driver *drv)


### PR DESCRIPTION
YVU420 plane number and UV plane length diff with NV12, crash when
copying data.

Jira: https://jira01.devtools.intel.com/browse/OAM-55982
Test: android.hardware.camera2.cts.ImageWriterTest#
      testYuvImageWriterReaderOperation

Signed-off-by: Yin, ZhiyeX <zhiyex.yin@intel.com>