### PR TITLE
update for avoid compile warning

### DIFF
--- a/cros_gralloc/cros_gralloc_helpers.cc
+++ b/cros_gralloc/cros_gralloc_helpers.cc
@@ -9,7 +9,7 @@
 #include "i915_private_android.h"
 
 #include <cstdlib>
-#include <cutils/log.h>
+#include <log/log.h>
 #include <sync/sync.h>
 #include <error.h>
 #include <unistd.h>


### PR DESCRIPTION
update for avoid compile warning "Deprecated: don't include cutils/log.h, use either android/log.h or log/log.h" [-W#warnings]

Jira: https://jira01.devtools.intel.com/browse/GSE-1141
Tests:compile on Android IVI
