### PR TITLE
Close fd if we aren't going to use it

### DIFF
--- a/cros_gralloc/cros_gralloc_driver.cc
+++ b/cros_gralloc/cros_gralloc_driver.cc
@@ -58,11 +58,14 @@ int32_t cros_gralloc_driver::init()
 				continue;
 
 			version = drmGetVersion(fd);
-			if (!version)
+			if (!version) {
+				close(fd);
 				continue;
+            }
 
 			if (undesired[i] && !strcmp(version->name, undesired[i])) {
 				drmFreeVersion(version);
+				close(fd);
 				continue;
 			}
 

--- a/cros_gralloc/gralloc1/cros_gralloc1_module.cc
+++ b/cros_gralloc/gralloc1/cros_gralloc1_module.cc
@@ -415,7 +415,6 @@ int32_t CrosGralloc1::lockFlex(buffer_handle_t bufferHandle,
 			       struct android_flex_layout *outData, int32_t acquireFence)
 {
 	int32_t ret = -EINVAL;
-	int32_t outReleaseFence = 0;
 	struct android_ycbcr ycbcrData;
 
 	/*Check the format and support only for YUV format */


### PR DESCRIPTION
File descriptors are left open and forgotten.
Make sure to clean up fds after use.

Jira: GSE-1595
Test: Build and boot on Android

Signed-off-by: Kevin Strasser <kevin.strasser@intel.com>