### PR TITLE
Partially revert "Added Support for 64bit RGB format"

### DIFF
--- a/cros_gralloc/i915_private_android.cc
+++ b/cros_gralloc/i915_private_android.cc
@@ -34,8 +34,6 @@ uint32_t i915_private_convert_format(int format)
 		return DRM_FORMAT_YUV422;
 	case HAL_PIXEL_FORMAT_P010_INTEL:
 		return DRM_FORMAT_P010;
-	case HAL_PIXEL_FORMAT_RGBA_FP16:
-		return DRM_FORMAT_XBGR161616;
 	case HAL_PIXEL_FORMAT_RGBA_1010102:
 		return DRM_FORMAT_ABGR2101010;
 	}
@@ -81,8 +79,6 @@ int32_t i915_private_invert_format(int format)
 		return HAL_PIXEL_FORMAT_YCbCr_422_SP;
 	case DRM_FORMAT_YUV422:
 		return HAL_PIXEL_FORMAT_YCbCr_422_888;
-	case DRM_FORMAT_XBGR161616:
-		return HAL_PIXEL_FORMAT_RGBA_FP16;
 	case DRM_FORMAT_ABGR2101010:
 		return HAL_PIXEL_FORMAT_RGBA_1010102;
 	default:

--- a/i915_private.c
+++ b/i915_private.c
@@ -24,7 +24,6 @@ static const uint32_t private_linear_source_formats[] = { DRM_FORMAT_R16,    DRM
 							  DRM_FORMAT_YUV420, DRM_FORMAT_YUV422,
 							  DRM_FORMAT_YUV444, DRM_FORMAT_NV21,
 							  DRM_FORMAT_P010, DRM_FORMAT_RGB888, DRM_FORMAT_BGR888,
-							  DRM_FORMAT_XRGB161616, DRM_FORMAT_XBGR161616,
 							  DRM_FORMAT_ABGR2101010 };
 
 static const uint32_t private_source_formats[] = { DRM_FORMAT_P010, DRM_FORMAT_NV12_Y_TILED_INTEL };
@@ -153,9 +152,6 @@ uint32_t i915_private_bpp_from_format(uint32_t format, size_t plane)
 		return 8;
 	case DRM_FORMAT_R16:
 		return 16;
-        case DRM_FORMAT_XRGB161616:
-        case DRM_FORMAT_XBGR161616:
-                return 64;
         case DRM_FORMAT_ABGR2101010:
                 return 32;
 	}
@@ -182,8 +178,6 @@ size_t i915_private_num_planes_from_format(uint32_t format)
 {
 	switch (format) {
 	case DRM_FORMAT_R16:
-        case DRM_FORMAT_XRGB161616:
-        case DRM_FORMAT_XBGR161616:
 	case DRM_FORMAT_ABGR2101010:
 		return 1;
 	case DRM_FORMAT_NV12_Y_TILED_INTEL:


### PR DESCRIPTION
This partially reverts commit 47bd806579dd
The Android framework uses successful allocation of
HAL_PIXEL_FORMAT_RGBA_FP16 to test for wide-gamut capabilities.
We don't want to advertise this, so let's revert.

This revert won't cause regression on CTS test case
android.hardware.cts.HardwareBufferTest#testCreate

android.graphics.cts.BitmapColorSpaceTest#test16bitHardware
can pass if the framework falls back to RGBA8888, as is the plan.

Jira: https://jira01.devtools.intel.com/browse/OAM-68897
Tests: test16bitHardware and testCreate both pass