### PR TITLE
Remove 32bit RGB format support

### DIFF
--- a/cros_gralloc/i915_private_android.cc
+++ b/cros_gralloc/i915_private_android.cc
@@ -34,8 +34,6 @@ uint32_t i915_private_convert_format(int format)
 		return DRM_FORMAT_YUV422;
 	case HAL_PIXEL_FORMAT_P010_INTEL:
 		return DRM_FORMAT_P010;
-	case HAL_PIXEL_FORMAT_RGBA_1010102:
-		return DRM_FORMAT_ABGR2101010;
 	}
 
 	return DRM_FORMAT_NONE;
@@ -79,8 +77,6 @@ int32_t i915_private_invert_format(int format)
 		return HAL_PIXEL_FORMAT_YCbCr_422_SP;
 	case DRM_FORMAT_YUV422:
 		return HAL_PIXEL_FORMAT_YCbCr_422_888;
-	case DRM_FORMAT_ABGR2101010:
-		return HAL_PIXEL_FORMAT_RGBA_1010102;
 	default:
 		cros_gralloc_error("Unhandled DRM format %4.4s", drmFormat2Str(format));
 	}

--- a/drv_priv.h
+++ b/drv_priv.h
@@ -104,6 +104,9 @@ struct backend {
 	                    BO_USE_SW_READ_OFTEN | BO_USE_SW_WRITE_OFTEN | \
                             BO_USE_SW_READ_RARELY | BO_USE_SW_WRITE_RARELY | BO_USE_TEXTURE
 
+#define BO_USE_SW_MASK BO_USE_SW_READ_OFTEN | BO_USE_SW_WRITE_OFTEN | \
+                       BO_USE_SW_READ_RARELY | BO_USE_SW_WRITE_RARELY
+
 #define LINEAR_METADATA (struct format_metadata) { 0, 1, DRM_FORMAT_MOD_NONE }
 // clang-format on
 

--- a/i915_private.c
+++ b/i915_private.c
@@ -23,8 +23,7 @@
 static const uint32_t private_linear_source_formats[] = { DRM_FORMAT_R16,    DRM_FORMAT_NV16,
 							  DRM_FORMAT_YUV420, DRM_FORMAT_YUV422,
 							  DRM_FORMAT_YUV444, DRM_FORMAT_NV21,
-							  DRM_FORMAT_P010, DRM_FORMAT_RGB888, DRM_FORMAT_BGR888,
-							  DRM_FORMAT_ABGR2101010 };
+							  DRM_FORMAT_P010, DRM_FORMAT_RGB888, DRM_FORMAT_BGR888 };
 
 static const uint32_t private_source_formats[] = { DRM_FORMAT_P010, DRM_FORMAT_NV12_Y_TILED_INTEL };
 
@@ -152,8 +151,6 @@ uint32_t i915_private_bpp_from_format(uint32_t format, size_t plane)
 		return 8;
 	case DRM_FORMAT_R16:
 		return 16;
-        case DRM_FORMAT_ABGR2101010:
-                return 32;
 	}
 
 	fprintf(stderr, "drv: UNKNOWN FORMAT %d\n", format);
@@ -178,7 +175,6 @@ size_t i915_private_num_planes_from_format(uint32_t format)
 {
 	switch (format) {
 	case DRM_FORMAT_R16:
-	case DRM_FORMAT_ABGR2101010:
 		return 1;
 	case DRM_FORMAT_NV12_Y_TILED_INTEL:
 	case DRM_FORMAT_NV16:

--- a/i915_private.c
+++ b/i915_private.c
@@ -23,7 +23,9 @@
 static const uint32_t private_linear_source_formats[] = { DRM_FORMAT_R16,    DRM_FORMAT_NV16,
 							  DRM_FORMAT_YUV420, DRM_FORMAT_YUV422,
 							  DRM_FORMAT_YUV444, DRM_FORMAT_NV21,
-							  DRM_FORMAT_P010, DRM_FORMAT_RGB888, DRM_FORMAT_BGR888 };
+							  DRM_FORMAT_P010 };
+
+static const uint32_t private_rgb24_formats[] = { DRM_FORMAT_RGB888, DRM_FORMAT_BGR888 };
 
 static const uint32_t private_source_formats[] = { DRM_FORMAT_P010, DRM_FORMAT_NV12_Y_TILED_INTEL };
 
@@ -107,6 +109,10 @@ int i915_private_add_combinations(struct driver *drv)
 	metadata.modifier = I915_FORMAT_MOD_Y_TILED;
 	drv_add_combinations(drv, private_source_formats, ARRAY_SIZE(private_source_formats),
 			     &metadata, texture_flags | BO_USE_CAMERA_MASK);
+
+        /* Android CTS tests require this. */
+        drv_add_combinations(drv, private_rgb24_formats, ARRAY_SIZE(private_rgb24_formats),
+                             &metadata, BO_USE_SW_MASK);
 
 	texture_flags &= ~BO_USE_RENDERSCRIPT;
 	texture_flags &= ~BO_USE_SW_WRITE_OFTEN;


### PR DESCRIPTION
HAL_PIXEL_FORMAT_RGBA_1010102 is added to fix CTS issue
android.hardware.cts.HardwareBufferTest#testCreate. In fact,
GL extensions should not be uesd to query for wide-gamut
support. As google has removed RGBA 10:10:10:2 format check
and HAL_PIXEL_FORMAT_RGBA_1010102 patch also cause other CTS
regression, let's remove it here.

Following case could pass with this patch
SingleLayer_ColorTest_GpuSampledImageCanBeSampled_R10G10B10A2_UNORM

CTS test case remove RGBA 10:10:10:2 format check
https://android-review.googlesource.com/c/platform/cts/+/733623

Tracked-On: https://jira01.devtools.intel.com/browse/OAM-70128