### PR TITLE
Yf tiled and Yf tiled CCS should be set Y Tile

### DIFF
--- a/i915.c
+++ b/i915.c
@@ -327,6 +327,8 @@ static int i915_bo_create_for_modifier(struct bo *bo, uint32_t width, uint32_t h
 		break;
 	case I915_FORMAT_MOD_Y_TILED:
 	case I915_FORMAT_MOD_Y_TILED_CCS:
+        case I915_FORMAT_MOD_Yf_TILED:
+        case I915_FORMAT_MOD_Yf_TILED_CCS:
 		bo->tiling = I915_TILING_Y;
 		break;
 	}


### PR DESCRIPTION
Otherwise it will cause sramble sceen issues in Android

Jira: None
Tests: Android UI/Video playback
Signed-off-by: Lin Johnson <johnson.lin@intel.com>