### PR TITLE
Mitigate GRALLOC1_PFN_LOCK_FLEX multithread issue.

### DIFF
--- a/cros_gralloc/gralloc1/cros_gralloc1_module.cc
+++ b/cros_gralloc/gralloc1/cros_gralloc1_module.cc
@@ -405,7 +405,7 @@ int32_t CrosGralloc1::lock(buffer_handle_t bufferHandle, gralloc1_producer_usage
 	return CROS_GRALLOC_ERROR_NONE;
 }
 
-android_flex_plane_t ycbcrplanes[3];
+thread_local android_flex_plane_t ycbcrplanes[3];
 
 int32_t update_flex_layout(struct android_ycbcr *ycbcr, struct android_flex_layout *outFlexLayout)
 {


### PR DESCRIPTION
lockFlex fills outFlexLayout->planes with pointer to global variable
ycbcrplanes, doesn't work from multiple threads.
Workaround: change the variable to thread_local.

Jira: OAM-70143, MDP-51191
Test: check memory regions mapped from different threads don't overlap