### PR TITLE
Support Android Q Gralloc 3.0 APIs

### DIFF
--- a/cros_gralloc/gralloc1/cros_gralloc1_module.cc
+++ b/cros_gralloc/gralloc1/cros_gralloc1_module.cc
@@ -314,6 +314,26 @@ int32_t CrosGralloc1::setModifier(gralloc1_buffer_descriptor_t descriptorId, uin
 	return CROS_GRALLOC_ERROR_NONE;
 }
 
+bool CrosGralloc1::IsSupported(struct cros_gralloc_buffer_descriptor *descriptor)
+{
+	uint64_t usage =
+	    cros_gralloc1_convert_usage(descriptor->producer_usage, descriptor->consumer_usage);
+	descriptor->use_flags = usage;
+	bool supported = driver->is_supported(descriptor);
+	if (!supported && (descriptor->consumer_usage & GRALLOC1_CONSUMER_USAGE_HWCOMPOSER)) {
+		descriptor->use_flags &= ~BO_USE_SCANOUT;
+		supported = driver->is_supported(descriptor);
+	}
+
+	if (!supported) {
+		cros_gralloc_error("Unsupported combination -- HAL format: %u, HAL flags: %u, "
+				   "drv_format: %u, drv_flags: %llu",
+				   descriptor->droid_format, usage, descriptor->drm_format,
+				   static_cast<unsigned long long>(descriptor->use_flags));
+	}
+	return supported;
+}
+
 int32_t CrosGralloc1::allocate(struct cros_gralloc_buffer_descriptor *descriptor,
 			       buffer_handle_t *outBufferHandle)
 {
@@ -401,6 +421,32 @@ int32_t CrosGralloc1::lock(buffer_handle_t bufferHandle, gralloc1_producer_usage
 		return CROS_GRALLOC_ERROR_BAD_HANDLE;
 
 	*outData = addr[0];
+
+	return CROS_GRALLOC_ERROR_NONE;
+}
+
+int32_t CrosGralloc1::lock(buffer_handle_t bufferHandle, gralloc1_producer_usage_t producerUsage,
+			   gralloc1_consumer_usage_t consumerUsage,
+			   const gralloc1_rect_t &accessRegion, void **outData,
+			   int32_t acquireFence, int32_t *bytesPerPixel, int32_t *bytesPerStride)
+{
+	uint64_t map_flags;
+	uint8_t *addr[DRV_MAX_PLANES];
+
+	auto hnd = cros_gralloc_convert_handle(bufferHandle);
+	if (!hnd) {
+		cros_gralloc_error("Invalid handle.");
+		return CROS_GRALLOC_ERROR_BAD_HANDLE;
+	}
+
+	map_flags = cros_gralloc1_convert_map_usage(producerUsage, consumerUsage);
+
+	if (driver->lock(bufferHandle, acquireFence, map_flags, addr))
+		return CROS_GRALLOC_ERROR_BAD_HANDLE;
+
+	*outData = addr[0];
+	*bytesPerPixel = drv_bytes_in_pixel_from_format(hnd->format);
+	*bytesPerStride = (*bytesPerPixel) * (int32_t)(hnd->pixel_stride);
 
 	return CROS_GRALLOC_ERROR_NONE;
 }

--- a/cros_gralloc/gralloc1/cros_gralloc1_module.h
+++ b/cros_gralloc/gralloc1/cros_gralloc1_module.h
@@ -219,6 +219,8 @@ class CrosGralloc1 : public gralloc1_device_t
 		return getAdapter(device)->getByteStride(buffer, outStride, size);
 	}
 
+	bool IsSupported(struct cros_gralloc_buffer_descriptor *descriptor);
+
 	// Buffer Management functions
 	int32_t allocate(struct cros_gralloc_buffer_descriptor *descriptor,
 			 buffer_handle_t *outBufferHandle);
@@ -241,6 +243,12 @@ class CrosGralloc1 : public gralloc1_device_t
 	int32_t lock(buffer_handle_t bufferHandle, gralloc1_producer_usage_t producerUsage,
 		     gralloc1_consumer_usage_t consumerUsage, const gralloc1_rect_t &accessRegion,
 		     void **outData, int32_t acquireFence);
+
+	int32_t lock(buffer_handle_t bufferHandle, gralloc1_producer_usage_t producerUsage,
+		     gralloc1_consumer_usage_t consumerUsage, const gralloc1_rect_t &accessRegion,
+		     void **outData, int32_t acquireFence, int32_t *bytesPerPixel,
+		     int32_t *bytesPerStride);
+
 	int32_t lockFlex(buffer_handle_t bufferHandle, gralloc1_producer_usage_t producerUsage,
 			 gralloc1_consumer_usage_t consumerUsage,
 			 const gralloc1_rect_t &accessRegion, struct android_flex_layout *outFlex,

--- a/drv.c
+++ b/drv.c
@@ -615,6 +615,11 @@ size_t drv_num_planes_from_format(uint32_t format)
 	return i915_private_num_planes_from_format(format);
 }
 
+int32_t drv_bytes_in_pixel_from_format(uint32_t format)
+{
+	return drv_bytes_from_format(format);
+}
+
 uint32_t drv_num_buffers_per_bo(struct bo *bo)
 {
 	uint32_t count = 0;

--- a/drv.h
+++ b/drv.h
@@ -147,6 +147,8 @@ uint32_t drv_resolve_format(struct driver *drv, uint32_t format, uint64_t use_fl
 
 size_t drv_num_planes_from_format(uint32_t format);
 
+int32_t drv_bytes_in_pixel_from_format(uint32_t format);
+
 uint32_t drv_num_buffers_per_bo(struct bo *bo);
 
 #ifdef __cplusplus

--- a/helpers.c
+++ b/helpers.c
@@ -127,6 +127,11 @@ uint32_t drv_stride_from_format(uint32_t format, uint32_t width, size_t plane)
 	return stride;
 }
 
+int32_t drv_bytes_from_format(uint32_t format)
+{
+	int32_t pixel = DIV_ROUND_UP(bpp_from_format(format, 0), 8);
+	return pixel;
+}
 uint32_t drv_size_from_format(uint32_t format, uint32_t stride, uint32_t height, size_t plane)
 {
 	assert(plane < drv_num_planes_from_format(format));

--- a/helpers.h
+++ b/helpers.h
@@ -10,6 +10,7 @@
 #include "drv.h"
 
 uint32_t drv_stride_from_format(uint32_t format, uint32_t width, size_t plane);
+int32_t drv_bytes_from_format(uint32_t format);
 uint32_t drv_size_from_format(uint32_t format, uint32_t stride, uint32_t height, size_t plane);
 int drv_bo_from_format(struct bo *bo, uint32_t stride, uint32_t aligned_height, uint32_t format);
 int drv_dumb_bo_create(struct bo *bo, uint32_t width, uint32_t height, uint32_t format,


### PR DESCRIPTION
Add bytesPerPixel and bytesPerStride return value in lock.
Add IsSupported function to check whether the buffer could be allocated.

Change-Id: Ib7efb0fb12057ff2125b99af8edd55c90a6ff8c2
Tracked-On: https://jira.devtools.intel.com/browse/OAM-79197
Tests: Build without error.
Signed-off-by: HeYue <yue.he@intel.com>