### PR TITLE
Do not expose BO_USE_RENDERING usage to NV12 format

### DIFF
--- a/i915_private.c
+++ b/i915_private.c
@@ -83,7 +83,7 @@ int i915_private_add_combinations(struct driver *drv)
 
 	drv_modify_combination(drv, DRM_FORMAT_ABGR8888, &metadata, BO_USE_CURSOR | BO_USE_SCANOUT);
 	drv_modify_combination(drv, DRM_FORMAT_NV12, &metadata,
-			       BO_USE_RENDERING | BO_USE_TEXTURE | BO_USE_CAMERA_MASK);
+			       BO_USE_TEXTURE | BO_USE_CAMERA_MASK);
 	drv_modify_combination(drv, DRM_FORMAT_YUYV, &metadata,
 			       BO_USE_TEXTURE | BO_USE_CAMERA_MASK | BO_USE_RENDERING);
 	drv_modify_combination(drv, DRM_FORMAT_VYUY, &metadata,


### PR DESCRIPTION
We don't support glEGLImageTargetRenderbufferStorageOES with format
NV12. However, we expose rendering usage in our gralloc.

Remove this flag and pass following CTS issues on
CtsNativeHardwareTestCases module

SingleLayer_ColorTest_GpuColorOutputIsRenderable_Y8Cb8Cr8_420
SingleLayer_ColorTest_GpuColorOutputCpuRead_Y8Cb8Cr8_420
SingleLayer_ColorTest_GpuColorOutputAndSampledImage_Y8Cb8Cr8_420

Jira: OAM-81090
Test: No regression on CTS test
Signed-off-by: Chenglei Ren <chenglei.ren@intel.com>