### PR TITLE
Fix klocwork issue in GFX domain

### DIFF
--- a/drv.c
+++ b/drv.c
@@ -167,6 +167,8 @@ void drv_destroy(struct driver *drv)
 {
 	ATOMIC_LOCK(&drv->driver_lock);
 
+       close(drv->fd);
+
 	if (drv->backend->close)
 		drv->backend->close(drv);
 


### PR DESCRIPTION
Add a resource release function.
The fd handle is blended with drv struct, so we can only close it in drv_destory function.