### PR TITLE
Add pixel format RGBA_FP16 and RGBA_1010102 support

### DIFF
--- a/cros_gralloc/gralloc1/cros_gralloc1_module.cc
+++ b/cros_gralloc/gralloc1/cros_gralloc1_module.cc
@@ -389,6 +389,14 @@ int32_t CrosGralloc1::allocate(struct cros_gralloc_buffer_descriptor *descriptor
 	    cros_gralloc1_convert_usage(descriptor->producer_usage, descriptor->consumer_usage);
 	descriptor->use_flags = usage;
 	bool supported = driver->is_supported(descriptor);
+
+	if(!supported && (descriptor->drm_format == DRM_FORMAT_ABGR2101010 ||
+	    descriptor->drm_format == DRM_FORMAT_ABGR16161616F)){
+		descriptor->use_flags &= ~BO_USE_RENDERING;
+		descriptor->use_flags &= ~BO_USE_TEXTURE;
+		supported = driver->is_supported(descriptor);
+        }
+
 	if (!supported && (descriptor->consumer_usage & GRALLOC1_CONSUMER_USAGE_HWCOMPOSER)) {
 		descriptor->use_flags &= ~BO_USE_SCANOUT;
 		supported = driver->is_supported(descriptor);

--- a/cros_gralloc/i915_private_android.cc
+++ b/cros_gralloc/i915_private_android.cc
@@ -34,6 +34,10 @@ uint32_t i915_private_convert_format(int format)
 		return DRM_FORMAT_YUV422;
 	case HAL_PIXEL_FORMAT_P010_INTEL:
 		return DRM_FORMAT_P010;
+	case HAL_PIXEL_FORMAT_RGBA_1010102:
+		return DRM_FORMAT_ABGR2101010;
+	case HAL_PIXEL_FORMAT_RGBA_FP16:
+		return DRM_FORMAT_ABGR16161616F;
 	}
 
 	return DRM_FORMAT_NONE;
@@ -77,6 +81,10 @@ int32_t i915_private_invert_format(int format)
 		return HAL_PIXEL_FORMAT_YCbCr_422_SP;
 	case DRM_FORMAT_YUV422:
 		return HAL_PIXEL_FORMAT_YCbCr_422_888;
+	case DRM_FORMAT_ABGR2101010:
+		return HAL_PIXEL_FORMAT_RGBA_1010102;
+	case DRM_FORMAT_ABGR16161616F:
+		return HAL_PIXEL_FORMAT_RGBA_FP16;
 	default:
 		cros_gralloc_error("Unhandled DRM format %4.4s", drmFormat2Str(format));
 	}

--- a/i915_private.c
+++ b/i915_private.c
@@ -29,6 +29,8 @@ static const uint32_t private_rgb24_formats[] = { DRM_FORMAT_RGB888, DRM_FORMAT_
 
 static const uint32_t private_source_formats[] = { DRM_FORMAT_P010, DRM_FORMAT_NV12_Y_TILED_INTEL };
 
+static const uint32_t private_rgba_format[] = { DRM_FORMAT_ABGR2101010, DRM_FORMAT_ABGR16161616F };
+
 #if !defined(DRM_CAP_CURSOR_WIDTH)
 #define DRM_CAP_CURSOR_WIDTH 0x8
 #endif
@@ -104,6 +106,12 @@ int i915_private_add_combinations(struct driver *drv)
 			     ARRAY_SIZE(private_linear_source_formats), &metadata,
 			     texture_flags | BO_USE_CAMERA_MASK);
 
+        metadata.tiling = I915_TILING_NONE;
+        metadata.priority = 1;
+        metadata.modifier = DRM_FORMAT_MOD_NONE;
+        drv_add_combinations(drv, private_rgba_format, ARRAY_SIZE(private_rgba_format), &metadata,
+                             BO_USE_SW_WRITE_OFTEN | BO_USE_SCANOUT);
+
 	metadata.tiling = I915_TILING_Y;
 	metadata.priority = 3;
 	metadata.modifier = I915_FORMAT_MOD_Y_TILED;
@@ -157,6 +165,10 @@ uint32_t i915_private_bpp_from_format(uint32_t format, size_t plane)
 		return 8;
 	case DRM_FORMAT_R16:
 		return 16;
+	case DRM_FORMAT_ABGR2101010:
+		return 32;
+	case DRM_FORMAT_ABGR16161616F:
+		return 64;
 	}
 
 	fprintf(stderr, "drv: UNKNOWN FORMAT %d\n", format);
@@ -181,6 +193,8 @@ size_t i915_private_num_planes_from_format(uint32_t format)
 {
 	switch (format) {
 	case DRM_FORMAT_R16:
+	case DRM_FORMAT_ABGR2101010:
+	case DRM_FORMAT_ABGR16161616F:
 		return 1;
 	case DRM_FORMAT_NV12_Y_TILED_INTEL:
 	case DRM_FORMAT_NV16:

--- a/i915_private.h
+++ b/i915_private.h
@@ -36,6 +36,7 @@ struct driver;
 /* 64 bpp RGB */
 #define DRM_FORMAT_XRGB161616  fourcc_code('X', 'R', '4', '8') /* [63:0] x:R:G:B 16:16:16:16 little endian */
 #define DRM_FORMAT_XBGR161616  fourcc_code('X', 'B', '4', '8') /* [63:0] x:B:G:R 16:16:16:16 little endian */
+#define DRM_FORMAT_ABGR16161616F  fourcc_code('A', 'B', '4', 'H') /* [63:0] x:B:G:R 16:16:16:16 little endian */
 
 int i915_private_init(struct driver *drv, uint64_t *cursor_width, uint64_t *cursor_height);
 


### PR DESCRIPTION
We add two pixel formats HAL_PIXEL_FORMAT_RGBA_FP16 and
HAL_PIXEL_FORMAT_RGBA_1010102 to minigbm, which could help
to pass all dEQP-VK.wsi.* issue.

Test: All dEQP-VK.wsi.* case pass and no regression on other CTS test
Change-Id: I21739f9c7001c7d4b21cc6e92edc9ea9072ffd1a
Tracked-On: OAM-84250
Signed-off-by: Chenglei Ren <chenglei.ren@intel.com>