### PR TITLE
Expose more usage for FP16 and RGBA1010102 format

### DIFF
--- a/cros_gralloc/gralloc1/cros_gralloc1_module.cc
+++ b/cros_gralloc/gralloc1/cros_gralloc1_module.cc
@@ -390,11 +390,10 @@ int32_t CrosGralloc1::allocate(struct cros_gralloc_buffer_descriptor *descriptor
 	descriptor->use_flags = usage;
 	bool supported = driver->is_supported(descriptor);
 
-	if(!supported && (descriptor->drm_format == DRM_FORMAT_ABGR2101010 ||
-	    descriptor->drm_format == DRM_FORMAT_ABGR16161616F)){
-		descriptor->use_flags &= ~BO_USE_RENDERING;
-		descriptor->use_flags &= ~BO_USE_TEXTURE;
-		supported = driver->is_supported(descriptor);
+	if(!supported && (descriptor->drm_format == DRM_FORMAT_ABGR2101010)){
+                descriptor->use_flags &= ~BO_USE_RENDERING;
+                descriptor->use_flags &= ~BO_USE_TEXTURE;
+                supported = driver->is_supported(descriptor);
         }
 
 	if (!supported && (descriptor->consumer_usage & GRALLOC1_CONSUMER_USAGE_HWCOMPOSER)) {

--- a/cros_gralloc/gralloc1/cros_gralloc1_module.cc
+++ b/cros_gralloc/gralloc1/cros_gralloc1_module.cc
@@ -390,12 +390,6 @@ int32_t CrosGralloc1::allocate(struct cros_gralloc_buffer_descriptor *descriptor
 	descriptor->use_flags = usage;
 	bool supported = driver->is_supported(descriptor);
 
-	if(!supported && (descriptor->drm_format == DRM_FORMAT_ABGR2101010)){
-                descriptor->use_flags &= ~BO_USE_RENDERING;
-                descriptor->use_flags &= ~BO_USE_TEXTURE;
-                supported = driver->is_supported(descriptor);
-        }
-
 	if (!supported && (descriptor->consumer_usage & GRALLOC1_CONSUMER_USAGE_HWCOMPOSER)) {
 		descriptor->use_flags &= ~BO_USE_SCANOUT;
 		supported = driver->is_supported(descriptor);

--- a/i915_private.c
+++ b/i915_private.c
@@ -29,8 +29,6 @@ static const uint32_t private_rgb24_formats[] = { DRM_FORMAT_RGB888, DRM_FORMAT_
 
 static const uint32_t private_source_formats[] = { DRM_FORMAT_P010, DRM_FORMAT_NV12_Y_TILED_INTEL };
 
-static const uint32_t private_rgba_format[] = { DRM_FORMAT_ABGR2101010, DRM_FORMAT_ABGR16161616F };
-
 #if !defined(DRM_CAP_CURSOR_WIDTH)
 #define DRM_CAP_CURSOR_WIDTH 0x8
 #endif
@@ -109,8 +107,10 @@ int i915_private_add_combinations(struct driver *drv)
         metadata.tiling = I915_TILING_NONE;
         metadata.priority = 1;
         metadata.modifier = DRM_FORMAT_MOD_NONE;
-        drv_add_combinations(drv, private_rgba_format, ARRAY_SIZE(private_rgba_format), &metadata,
-                             BO_USE_SW_WRITE_OFTEN | BO_USE_SCANOUT);
+	drv_add_combination(drv, DRM_FORMAT_ABGR2101010, &metadata,
+                             BO_USE_SCANOUT);
+        drv_add_combination(drv, DRM_FORMAT_ABGR16161616F, &metadata,
+                             BO_USE_SCANOUT | BO_USE_TEXTURE | BO_USE_RENDERING);
 
 	metadata.tiling = I915_TILING_Y;
 	metadata.priority = 3;

--- a/i915_private.c
+++ b/i915_private.c
@@ -108,7 +108,8 @@ int i915_private_add_combinations(struct driver *drv)
         metadata.priority = 1;
         metadata.modifier = DRM_FORMAT_MOD_NONE;
 	drv_add_combination(drv, DRM_FORMAT_ABGR2101010, &metadata,
-                             BO_USE_SCANOUT);
+                             BO_USE_SCANOUT | BO_USE_TEXTURE |
+                             BO_USE_RENDERING | BO_USE_SW_MASK);
         drv_add_combination(drv, DRM_FORMAT_ABGR16161616F, &metadata,
                              BO_USE_SCANOUT | BO_USE_TEXTURE | BO_USE_RENDERING);
 


### PR DESCRIPTION
Android 10 asks to support this two format with more usage.