### PR TITLE
getBackingStore() return unique value

### DIFF
--- a/cros_gralloc/cros_gralloc_driver.cc
+++ b/cros_gralloc/cros_gralloc_driver.cc
@@ -325,13 +325,7 @@ int32_t cros_gralloc_driver::get_backing_store(buffer_handle_t handle, uint64_t 
 		return -EINVAL;
 	}
 
-	auto buffer = get_buffer(hnd);
-	if (!buffer) {
-		cros_gralloc_error("Invalid Reference.");
-		return -EINVAL;
-	}
-
-	*out_store = static_cast<uint64_t>(buffer->get_id());
+	*out_store = static_cast<uint64_t>(hnd->id);
 	return 0;
 }
 


### PR DESCRIPTION
getBackingStore() should return a globally unique value for a
dedicated graphics buffer, the graphics buffers will share between
different modules like display and codec, the unique value will be
used to identify specifi memory.

Tracked-On: OAM-97062
Signed-off-by: Yang, Dong <dong.yang@intel.com>